### PR TITLE
Feature/safety override and clean wallet

### DIFF
--- a/ocean-client/src/programs/common-program.ts
+++ b/ocean-client/src/programs/common-program.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "@defichain/jellyfish-api-core";
-import { CTransactionSegWit, TokenBalance, TransactionSegWit } from "@defichain/jellyfish-transaction";
+import { CTransactionSegWit, ScriptBalances, TokenBalance, TransactionSegWit } from "@defichain/jellyfish-transaction";
 import { JellyfishWallet, WalletHdNode } from "@defichain/jellyfish-wallet";
 import { WhaleApiClient } from "@defichain/whale-api-client";
 import { AddressToken } from "@defichain/whale-api-client/dist/api/address";
@@ -162,6 +162,17 @@ export class CommonProgram {
                 token: token,
                 amount: amount
             }
+        }, script)
+
+        return this.send(txn)
+    }
+
+    
+    async utxoToOwnAccount(amount: BigNumber) : Promise<string> {
+        const script = await this.account!.getScript()
+        const balances : ScriptBalances[] = [{script:script, balances:[{token:0,amount:amount}]}] //DFI has tokenId 0
+        const txn = await this.account!.withTransactionBuilder().account.utxosToAccount({
+            to: balances
         }, script)
 
         return this.send(txn)

--- a/ocean-client/src/programs/vault-maxi-program.ts
+++ b/ocean-client/src/programs/vault-maxi-program.ts
@@ -140,9 +140,9 @@ export class VaultMaxiProgram extends CommonProgram {
             const neededLPtokens: number = +((await this.getTokenBalance(this.lmPair))?.amount ?? "0")
             if (neededLPtokens > +lpTokens.amount || neededDusd > +dusdLoan.amount || neededStock > +tokenLoan.amount) {
                 const message = "vault ratio not safe but not enough lptokens or loans to be able to guard it. Did you change the LMToken? Your vault is NOT safe! "
-                    + neededLPtokens + " vs " + lpTokens.amount + " " + lpTokens.symbol + "\n"
-                    + neededDusd + " vs " + dusdLoan.amount + " " + dusdLoan.symbol + "\n"
-                    + neededStock + " vs " + tokenLoan.amount + " " + tokenLoan.symbol + "\n"
+                    + neededLPtokens.toFixed(4) + " vs " + (+lpTokens.amount).toFixed(4) + " " + lpTokens.symbol + "\n"
+                    + neededDusd.toFixed(1) + " vs " + (+dusdLoan.amount).toFixed(1) + " " + dusdLoan.symbol + "\n"
+                    + neededStock.toFixed(4) + " vs " + (+tokenLoan.amount).toFixed(4) + " " + tokenLoan.symbol + "\n"
                 await telegram.send(message)
                 console.warn(message)
                 return true //can still run

--- a/ocean-client/src/programs/vault-maxi-program.ts
+++ b/ocean-client/src/programs/vault-maxi-program.ts
@@ -117,8 +117,11 @@ export class VaultMaxiProgram extends CommonProgram {
         }
 
         // showstoppers checked, now check for warnings
-
-        const safeCollRatio = +vault.loanScheme.minColRatio * 2
+        const safetyOverride= process.env.VAULTMAXI_VAULT_SAFETY_OVERRIDE ? +(process.env.VAULTMAXI_VAULT_SAFETY_OVERRIDE) : undefined
+        const safeCollRatio = safetyOverride ?? +vault.loanScheme.minColRatio * 2
+        if(safetyOverride) {
+            console.log("using override for vault safety level: "+safetyOverride)
+        }
         if (+vault.collateralRatio < safeCollRatio) {
             //check if we could provide safety
             const balances = await this.getTokenBalances()
@@ -159,7 +162,7 @@ export class VaultMaxiProgram extends CommonProgram {
         let pool = await this.getPool(this.lmPair)
 
         values.address= walletAddress === this.settings.address ? walletAddress : undefined
-        values.vault = vault?.vaultId === this.settings.vault && vault.ownerAddress == walletAddress ? vault.vaultId : undefined
+        values.vault = (vault?.vaultId === this.settings.vault && vault.ownerAddress == walletAddress) ? vault.vaultId : undefined
         values.minCollateralRatio = this.settings.minCollateralRatio
         values.maxCollateralRatio = this.settings.maxCollateralRatio
         values.LMToken = (pool && pool.symbol == this.lmPair) ? this.settings.LMToken : undefined

--- a/ocean-client/src/programs/vault-maxi-program.ts
+++ b/ocean-client/src/programs/vault-maxi-program.ts
@@ -327,7 +327,6 @@ export class VaultMaxiProgram extends CommonProgram {
             const amount= utxoBalance.minus(1)
             console.log("converting " + amount + " UTXOs to token ")
             const tx= await this.utxoToOwnAccount(amount)
-            //@Krysh ok if we flag this also as reinvest? or different transaction? if we have a timeout after this, we don't need a cleanup
             await this.updateToState(ProgramState.WaitingForTransaction, VaultMaxiProgramTransaction.Reinvest, tx) 
             if (! await this.waitForTx(tx)) {
                 await telegram.send("ERROR: converting UTXOs failed")

--- a/ocean-client/src/programs/vault-maxi-program.ts
+++ b/ocean-client/src/programs/vault-maxi-program.ts
@@ -169,7 +169,7 @@ export class VaultMaxiProgram extends CommonProgram {
         values.reinvest= this.settings.reinvestThreshold
 
         const message = values.constructMessage() + "\n" 
-                    + (this.keepWalletClean ? "trying to keep the wallet clean" : "ignoring dust and comissions")
+                    + (this.keepWalletClean ? "trying to keep the wallet clean" : "ignoring dust and commissions")
         console.log(message)
         await telegram.send(message)
         await telegram.log("log channel active")


### PR DESCRIPTION
I added the discussed "clean wallet" feature. can be disabled via envVariable
also a possible override for the vault safety level.

I think it might be a good way moving forward to have general settings in the parameters ( easy to maintain via cloudFormation) and pro-user settings (which standard users shouldn't use/change) into environment variables. what do you think?