### PR TITLE
reinvest: threshold now blocks complete reinvest, not only auto donation

### DIFF
--- a/ocean-client/README.md
+++ b/ocean-client/README.md
@@ -95,6 +95,11 @@ Besides having parameters in the AWS ParameterStore, there is the possibility to
 
 Currently following keys are respected with a small description on how they alter execution functionality
 
+### VAULTMAXI_MAXREINVEST
+value: number
+
+With default behaviour, a reinvest only happens if the accumulated DFI is less then twice the threshold. Anything above that is assumed to be a transfer of funds and therefore no action is taken (no processing according to reinvest pattern, no auto donation). Setting this environment variable, increases the threshold. With this you can force VaultMaxi to process even larger amounts as reinvests.
+
 ### VAULTMAXI_LOGID
 (overrides the parameter `/defichain-maxi/settings/log-id` but same functionality)
 value: string

--- a/ocean-client/src/programs/lm-reinvest-program.ts
+++ b/ocean-client/src/programs/lm-reinvest-program.ts
@@ -107,10 +107,13 @@ export class LMReinvestProgram extends CommonProgram {
   }
 
   async checkAndDoReinvest(balances: Map<string, AddressToken>, telegram: Telegram): Promise<boolean> {
-    const maxReinvestForDonation = Math.max(this.getSettings().reinvestThreshold!, 20) * 2 //anything below 20 DFI is considered a "reinvest all the time"
+    const maxReinvestThreshold = Math.max(
+      this.getSettings().reinvestThreshold! * 2,
+      +(process.env.VAULTMAXI_MAXREINVEST ?? 40),
+    ) //anything below 20 DFI is considered a "reinvest all the time"
 
     const result = await checkAndDoReinvest(
-      maxReinvestForDonation,
+      maxReinvestThreshold,
       balances,
       telegram,
       this,

--- a/ocean-client/src/programs/vault-maxi-program.ts
+++ b/ocean-client/src/programs/vault-maxi-program.ts
@@ -1625,20 +1625,20 @@ export class VaultMaxiProgram extends CommonProgram {
   ): Promise<boolean> {
     let dfiCollateral = vault.collateralAmounts.find((coll) => coll.symbol === 'DFI')
     let dfiPrice = dfiCollateral?.activePrice?.active?.amount
-    let maxReinvestForDonation = this.getSettings().reinvestThreshold ?? 0
+    let maxReinvestThreshold = this.getSettings().reinvestThreshold ?? 0
     if (dfiPrice && pool.apr) {
       //35040 executions per year -> this is the expected reward per maxi trigger in DFI, every reinvest below that number is pointless
-      maxReinvestForDonation = Math.max(
-        maxReinvestForDonation,
+      maxReinvestThreshold = Math.max(
+        maxReinvestThreshold,
         (+vault.loanValue * pool.apr.reward) / (35040 * +dfiPrice),
       )
     } else {
-      maxReinvestForDonation = Math.max(maxReinvestForDonation, 10) //fallback to min 10 DFI reinvest
+      maxReinvestThreshold = Math.max(maxReinvestThreshold, 10) //fallback to min 10 DFI reinvest
     }
-    maxReinvestForDonation *= 2 //anything above twice the expected reinvest value is considered a transfer of funds
-
+    maxReinvestThreshold *= 2 //anything above twice the expected reinvest value is considered a transfer of funds
+    maxReinvestThreshold = Math.max(maxReinvestThreshold, +(process.env.VAULTMAXI_MAXREINVEST ?? 0))
     const result = await checkAndDoReinvest(
-      maxReinvestForDonation,
+      maxReinvestThreshold,
       balances,
       telegram,
       this,


### PR DESCRIPTION
otherwise we risk swapping and sending funds on transfer of funds. which is usually unintended