### PR TITLE
maxi: moved logId handling (with env) to settings)

### DIFF
--- a/ocean-client/src/utils/store_aws_maxi.ts
+++ b/ocean-client/src/utils/store_aws_maxi.ts
@@ -153,7 +153,7 @@ export class StoreAWSMaxi extends StoreAWS implements IStoreMaxi {
     settings.stateInformation = ProgramStateConverter.fromValue(this.getValue(StateKey, parameters))
     settings.stableCoinArbBatchSize = this.getNumberValue(StableArbBatchSizeKey, parameters) ?? -1
     settings.shouldSkipNext = (this.getValue(SkipKey, parameters) ?? 'false') === 'true'
-    settings.logId = this.getOptionalValue(LogIdKey, parameters)
+    settings.logId = process.env.VAULTMAXI_LOGID ?? this.getOptionalValue(LogIdKey, parameters)
     settings.keepWalletClean = this.getBooleanValue(KeepWalletCleanKey, parameters) ?? true
     settings.oceanUrl = this.getOptionalValue(OceanUrlKey, parameters)
     settings.logLevel = logLevelFromParam(this.getOptionalValue(LogLevelKey, parameters))

--- a/ocean-client/src/vault-maxi.ts
+++ b/ocean-client/src/vault-maxi.ts
@@ -67,7 +67,7 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
     }
     console.log('using oceans ' + JSON.stringify(oceansToUse))
 
-    const usedLogId = process.env.VAULTMAXI_LOGID ?? settings.logId
+    const usedLogId = settings.logId
     const logId = usedLogId && usedLogId.length > 0 ? ' ' + usedLogId : ''
     const telegram = new Telegram(settings, '[Maxi' + store.paramPostFix + ' ' + VERSION + logId + ']')
 


### PR DESCRIPTION
doesn't change the current behaviour but clarifies it: logId is defined in reading the settings (now both in local app and AWS version)