### PR TITLE
Add possibility to use stablecoin pools via vaultmaxi

### DIFF
--- a/ocean-client/src/programs/testnetbot-program.ts
+++ b/ocean-client/src/programs/testnetbot-program.ts
@@ -104,11 +104,11 @@ export class TestnetBotProgram extends CommonProgram {
     let path: PoolId[] | undefined
     let loops = 1
     if (ratioIn.gt(1.05)) {
-      loops = ratioIn.toNumber()
+      loops = ratioIn.toNumber() + 1
       path = [{ id: +usdtPool.id }, { id: +dusdPool.id }, { id: +dusdusdtPool.id }]
     }
     if (ratioOut.gt(1.05)) {
-      loops = ratioOut.toNumber()
+      loops = ratioOut.toNumber() + 1
       path = [{ id: +dusdusdtPool.id }, { id: +dusdPool.id }, { id: +usdtPool.id }]
     }
     if (path != undefined) {

--- a/ocean-client/src/programs/vault-maxi-program.ts
+++ b/ocean-client/src/programs/vault-maxi-program.ts
@@ -480,7 +480,7 @@ export class VaultMaxiProgram extends CommonProgram {
               )
 
             const neededAssetB = neededLPtokens.times(pool.tokenB.reserve).div(pool.totalLiquidity.token)
-            if (neededLPtokens.gt(lpTokens.amount) || neededAssetB.gt(ALoan!.amount)) {
+            if (neededLPtokens.gt(lpTokens.amount) || neededAssetB.gt(BLoan!.amount)) {
               message +=
                 `would need ${neededLPtokens.toFixed(4)} but got ${(+lpTokens.amount).toFixed(4)} ${lpTokens.symbol
                 }.\n` +
@@ -1186,7 +1186,7 @@ export class VaultMaxiProgram extends CommonProgram {
       // add stable-DUSD case
       let oracleB = new BigNumber(1) //DUSD in loans is fixed 1
 
-      const coll = vault.collateralAmounts.find((coll) => coll.symbol === this.assetB)
+      const coll = vault.collateralAmounts.find((coll) => coll.symbol === this.assetA)
       const oracleA = this.getUsedOraclePrice(coll, true)
       const assetAInColl = coll?.amount ?? '0'
 

--- a/ocean-client/src/programs/vault-maxi-program.ts
+++ b/ocean-client/src/programs/vault-maxi-program.ts
@@ -1327,10 +1327,6 @@ export class VaultMaxiProgram extends CommonProgram {
           this.assetB,
       )
 
-      loanArray = [
-        { token: +pool.tokenA.id, amount: wantedAssetA },
-        { token: +pool.tokenB.id, amount: wantedAssetB },
-      ]
       //check if enough collateral is there to even take new loan
       //dusdDFI * 2 >= loan+additionLoan * minRatio
       if (
@@ -1359,8 +1355,25 @@ export class VaultMaxiProgram extends CommonProgram {
         await telegram.send(msg, LogLevel.INFO)
         wantedAssetA = possibleLoan.div(BigNumber.sum(oracleA, pool.priceRatio.ba))
         wantedAssetB = wantedAssetA.multipliedBy(pool.priceRatio.ba)
+        console.log(
+          'reduced increasing to ' +
+            possibleLoan +
+            ' USD, taking loan ' +
+            wantedAssetA.toFixed(4) +
+            '@' +
+            this.assetA +
+            ', ' +
+            wantedAssetB.toFixed(4) +
+            '@' +
+            this.assetB,
+        )
       }
+      loanArray = [
+        { token: +pool.tokenA.id, amount: wantedAssetA },
+        { token: +pool.tokenB.id, amount: wantedAssetB },
+      ]
     }
+    console.log('taking loans ' + JSON.stringify(loanArray))
     const takeLoanTx = await this.takeLoans(loanArray, prevout)
     await this.updateToState(ProgramState.WaitingForTransaction, VaultMaxiProgramTransaction.TakeLoan, takeLoanTx.txId)
     if (this.keepWalletClean) {

--- a/ocean-client/src/programs/vault-maxi-program.ts
+++ b/ocean-client/src/programs/vault-maxi-program.ts
@@ -455,6 +455,7 @@ export class VaultMaxiProgram extends CommonProgram {
             `VaultMaxi could only reach a collRatio of ${safetyLevel.toFixed(0)}%. This is not safe!\n` +
             'It is highly recommend to fix this!\n' +
             `To be able to reach a safe collRatio of ${safeCollRatio.toFixed(0)}% it\n`
+          let shouldSend = false
           if (this.isSingleMintA) {
             let oracleA = this.getUsedOraclePrice(ALoan, false)
             let oracleB = this.getUsedOraclePrice(
@@ -476,8 +477,7 @@ export class VaultMaxiProgram extends CommonProgram {
                   lpTokens.symbol
                 }.\n` +
                 `would need ${neededAssetA.toFixed(4)} but got ${(+ALoan!.amount).toFixed(4)} ${ALoan!.symbol}.\n`
-
-              await telegram.send(message, LogLevel.WARNING) //warning or error? action is recommended but not required?
+              shouldSend = true
             }
           } else if (this.isSingleMintB) {
             // case stable-DUSD
@@ -502,8 +502,7 @@ export class VaultMaxiProgram extends CommonProgram {
                   lpTokens.symbol
                 }.\n` +
                 `would need ${neededAssetB.toFixed(4)} but got ${(+BLoan!.amount).toFixed(4)} ${BLoan!.symbol}.\n`
-
-              await telegram.send(message, LogLevel.WARNING) //warning or error? action is recommended but not required?
+              shouldSend = true
             }
           } else {
             //case dToken-DUSD
@@ -520,8 +519,11 @@ export class VaultMaxiProgram extends CommonProgram {
                 }.\n` +
                 `would need ${neededDusd.toFixed(1)} but got ${(+BLoan!.amount).toFixed(1)} ${BLoan!.symbol}.\n` +
                 `would need ${neededStock.toFixed(4)} but got ${(+ALoan!.amount).toFixed(4)} ${ALoan!.symbol}.\n`
-              await telegram.send(message, LogLevel.WARNING) //@krysh is this warning or error?
+              shouldSend = true
             }
+          }
+          if (shouldSend) {
+            await telegram.send(message, LogLevel.WARNING) //warning cause action is recommended but not required
           }
         }
       }

--- a/ocean-client/src/programs/vault-maxi-program.ts
+++ b/ocean-client/src/programs/vault-maxi-program.ts
@@ -80,15 +80,12 @@ export class VaultMaxiProgram extends CommonProgram {
   private readonly minValueForCleanup: number = 1
   private readonly maxPercentDiffInConsistencyChecks: number = 1
 
-  public readonly dusdTokenId: number
-
   private reinvestTargets: ReinvestTarget[] = []
 
   private readonly STABLE_COINS = ['USDT', 'USDC', 'EUROC', 'XCHF']
 
   constructor(maxiStore: IStoreMaxi, settings: StoredMaxiSettings, walletSetup: WalletSetup) {
     super(maxiStore, settings, walletSetup)
-    this.dusdTokenId = walletSetup.isTestnet() ? 11 : 15
     this.lmPair = this.getSettings().LMPair
     ;[this.assetA, this.assetB] = this.lmPair.split('-')
     this.mainCollateralAsset = this.getSettings().mainCollateralAsset
@@ -113,12 +110,7 @@ export class VaultMaxiProgram extends CommonProgram {
     let result = await super.init()
     const blockheight = await this.getBlockHeight()
     console.log(
-      'initialized at block ' +
-        blockheight +
-        ' dusd CollValue is ' +
-        this.getCollateralFactor('' + this.dusdTokenId).toFixed(3) +
-        ' min value for cleanup is $' +
-        this.minValueForCleanup.toFixed(2),
+      'initialized at block ' + blockheight + ' min value for cleanup is $' + this.minValueForCleanup.toFixed(2),
     )
     let pattern = this.getSettings().reinvestPattern
     if (pattern === undefined || pattern === '') {
@@ -1816,8 +1808,8 @@ export class VaultMaxiProgram extends CommonProgram {
       )
       wantedTokens = neededrepayForRefRatio.times(referenceRatio / 100).div(
         BigNumber.sum(
-          oracleA.times(pool.tokenA.reserve), 
-          oracleB.times(pool.tokenB.reserve).times(referenceRatio / 100),//additional "times" due to part collateral, part loan
+          oracleA.times(pool.tokenA.reserve),
+          oracleB.times(pool.tokenB.reserve).times(referenceRatio / 100), //additional "times" due to part collateral, part loan
         ),
       )
     } else {

--- a/ocean-client/src/vault-maxi.ts
+++ b/ocean-client/src/vault-maxi.ts
@@ -29,7 +29,7 @@ class maxiEvent {
 
 const MIN_TIME_PER_ACTION_MS = 300 * 1000 //min 5 minutes for action. probably only needs 1-2, but safety first?
 
-export const VERSION = 'v2.5.2'
+export const VERSION = 'v2.6.0a'
 
 export async function main(event: maxiEvent, context: any): Promise<Object> {
   console.log('vault maxi ' + VERSION)

--- a/ocean-client/src/vault-maxi.ts
+++ b/ocean-client/src/vault-maxi.ts
@@ -35,9 +35,9 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
   console.log('vault maxi ' + VERSION)
   let blockHeight = 0
   let cleanUpTries = 0
-  // adding multiples so that we alternate the first retries
-  let mainOceansToUse = ['https://ocean.defichain.com']
-  let testOceansToUse = ['https://testnet.ocean.jellyfishsdk.com']
+  // adding multiples so that we alternate the first retries.
+  let mainOceansToUse = ['https://ocean.defichain.com', 'https://ocean.mydefichain.com']
+  let testOceansToUse = ['https://testnet.ocean.jellyfishsdk.com', 'https://testnet-ocean.mydefichain.com:8443']
   if (process.env.VAULTMAXI_OCEAN_URL) {
     mainOceansToUse.push(process.env.VAULTMAXI_OCEAN_URL.trim())
     testOceansToUse.push(process.env.VAULTMAXI_OCEAN_URL.trim())

--- a/ocean-client/src/vault-maxi.ts
+++ b/ocean-client/src/vault-maxi.ts
@@ -273,7 +273,7 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
           ') pair ' +
           settings.LMPair +
           ', ' +
-          (program.isSingle() ? 'minting only ' + program.assetA : 'minting both'),
+        program.getMintingMessage(),
       )
       let exposureChanged = false
 

--- a/ocean-client/src/vault-maxi.ts
+++ b/ocean-client/src/vault-maxi.ts
@@ -257,6 +257,9 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
         return { statusCode: 200 }
       }
 
+      const oldRatio = +vault.collateralRatio
+      const nextRatio = program.nextCollateralRatio(vault)
+      const usedCollateralRatio = BigNumber.min(vault.collateralRatio, nextRatio)
       //if DUSD loan is involved and current interest rate on DUSD is above LM rewards -> remove Exposure
       if (settings.mainCollateralAsset !== 'DUSD') {
         const poolApr = (pool!.apr?.total ?? 0) * 100
@@ -273,14 +276,13 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
             poolApr.toFixed(4),
         )
         if (pool?.apr?.total && interest > poolApr) {
-          await telegram.send('interest rate higher than APR -> removing/preventing exposure', LogLevel.INFO)
+          if (usedCollateralRatio.gt(0)) {
+            await telegram.send('interest rate higher than APR -> removing/preventing exposure', LogLevel.INFO)
+          }
           settings.maxCollateralRatio = -1
         }
       }
 
-      const oldRatio = +vault.collateralRatio
-      const nextRatio = program.nextCollateralRatio(vault)
-      const usedCollateralRatio = BigNumber.min(vault.collateralRatio, nextRatio)
       console.log(
         'starting with ' +
           vault.collateralRatio +

--- a/ocean-client/src/vault-maxi.ts
+++ b/ocean-client/src/vault-maxi.ts
@@ -258,8 +258,8 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
       }
 
       const oldRatio = +vault.collateralRatio
-      const nextRatio = program.nextCollateralRatio(vault)
-      const usedCollateralRatio = BigNumber.min(vault.collateralRatio, nextRatio)
+      var nextRatio = program.nextCollateralRatio(vault)
+      var usedCollateralRatio = BigNumber.min(vault.collateralRatio, nextRatio)
       //if DUSD loan is involved and current interest rate on DUSD is above LM rewards -> remove Exposure
       if (settings.mainCollateralAsset !== 'DUSD') {
         const poolApr = (pool!.apr?.total ?? 0) * 100
@@ -297,7 +297,7 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
           ') pair ' +
           settings.LMPair +
           ', ' +
-        program.getMintingMessage(),
+          program.getMintingMessage(),
       )
       let exposureChanged = false
 
@@ -308,6 +308,8 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
         vault = (await program.getVault()) as LoanVaultActive
         balances = await program.getTokenBalances()
         pool = await program.getPool(program.lmPair)
+        nextRatio = program.nextCollateralRatio(vault)
+        usedCollateralRatio = BigNumber.min(vault.collateralRatio, nextRatio)
         if (!program.consistencyChecks(vault)) {
           console.warn('consistency checks failed. will remove exposure')
           await telegram.send(

--- a/ocean-client/src/vault-maxi.ts
+++ b/ocean-client/src/vault-maxi.ts
@@ -263,15 +263,17 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
       //if DUSD loan is involved and current interest rate on DUSD is above LM rewards -> remove Exposure
       if (settings.mainCollateralAsset !== 'DUSD') {
         const poolApr = (pool!.apr?.total ?? 0) * 100
-        const dusdToken = await program.getLoanToken('' + program.dusdTokenId)
-        let interest = +vault.loanScheme.interestRate + +dusdToken.interest
+        const dusdToken = (await program.client.loan.listLoanToken(1000))?.find(
+          (token) => token.token.symbolKey == 'DUSD',
+        )
+        let interest = +vault.loanScheme.interestRate + +(dusdToken?.interest ?? 0)
         console.log(
           'DUSD currently has a total interest of ' +
             interest.toFixed(4) +
             ' = ' +
             vault.loanScheme.interestRate +
             ' + ' +
-            dusdToken.interest +
+            dusdToken?.interest +
             ' vs APR of ' +
             poolApr.toFixed(4),
         )

--- a/ocean-client/src/vault-maxi.ts
+++ b/ocean-client/src/vault-maxi.ts
@@ -258,8 +258,8 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
       }
 
       //if DUSD loan is involved and current interest rate on DUSD is above LM rewards -> remove Exposure
-      if (settings.mainCollateralAsset === 'DFI') {
-        const poolApr = (pool?.apr?.total ?? 0) * 100
+      if (settings.mainCollateralAsset !== 'DUSD') {
+        const poolApr = (pool!.apr?.total ?? 0) * 100
         const dusdToken = await program.getLoanToken('' + program.dusdTokenId)
         let interest = +vault.loanScheme.interestRate + +dusdToken.interest
         console.log(
@@ -272,7 +272,7 @@ export async function main(event: maxiEvent, context: any): Promise<Object> {
             ' vs APR of ' +
             poolApr.toFixed(4),
         )
-        if (interest > poolApr) {
+        if (pool?.apr?.total && interest > poolApr) {
           await telegram.send('interest rate higher than APR -> removing/preventing exposure', LogLevel.INFO)
           settings.maxCollateralRatio = -1
         }


### PR DESCRIPTION
Goal:

If stablecoin pool is defined as poolpair, maxi takes DUSD loan and pairs it with the stablecoin which needs to be in the collateral.

Future version might add an automatic swap of DUSD to the stablecoin if not enough is in the collateral. This version will behave exactly like the DUSD-DFI single-mint case.